### PR TITLE
Update VS Code and add VSCodium extension links

### DIFF
--- a/jekyll/faq.md
+++ b/jekyll/faq.md
@@ -45,7 +45,10 @@ glue code thanks to powerful metaprogramming capabilities of Nim.
 
 ## What about editor support?
 
-- Visual Studio Code: [https://marketplace.visualstudio.com/items?itemName=kosz78.nim](https://marketplace.visualstudio.com/items?itemName=kosz78.nim)
+- Visual Studio Code:
+  - Extension written in Nim [https://marketplace.visualstudio.com/items?itemName=nimsaem.nimvscode](https://marketplace.visualstudio.com/items?itemName=nimsaem.nimvscode)
+  - Original Extension written in TypeScript [https://marketplace.visualstudio.com/items?itemName=kosz78.nim](https://marketplace.visualstudio.com/items?itemName=kosz78.nim)
+- VSCodium/OpenVSX: [https://open-vsx.org/extension/nimsaem/nimvscode](https://open-vsx.org/extension/nimsaem/nimvscode)
 - Emacs: [https://github.com/nim-lang/nim-mode](https://github.com/nim-lang/nim-mode)
 - Vim: [https://github.com/zah/nimrod.vim/](https://github.com/zah/nimrod.vim)
 - NeoVim: [https://github.com/alaviss/nim.nvim](https://github.com/alaviss/nim.nvim)


### PR DESCRIPTION
- Reference to both the original TypeScript extension and the new Nim extension
- Also added a VSCodium reference for those that don't wish to use MS' version